### PR TITLE
feat: hide globe on mobile in bento grid

### DIFF
--- a/components/BentoGrid.tsx
+++ b/components/BentoGrid.tsx
@@ -79,7 +79,7 @@ export default function BentoGrid(): React.ReactElement {
 						backgroundComponent={
 							<Globe
 								config={EVENTS_GLOBE_CONFIG}
-								className="inset-auto! absolute right-0 bottom-0 translate-x-1/3 translate-y-1/3 size-125 opacity-50 md:size-162.5"
+								className="hidden md:block inset-auto! absolute right-0 bottom-0 translate-x-1/3 translate-y-1/3 size-125 opacity-50 md:size-162.5"
 							/>
 						}
 					/>


### PR DESCRIPTION
Update the Events card globe background to be desktop-only by adding
responsive visibility classes (hidden md:block). This improves mobile
layout by hiding the decorative globe element on smaller screens.