### PR TITLE
Add table of contents to Terms and Privacy pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -43,8 +43,32 @@ export default function PrivacyPage() {
           </p>
         </div>
 
+        {/* Table of Contents */}
+        <div className="mb-12 rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 font-grotesk text-xl font-bold text-foreground">
+            Table of Contents
+          </h2>
+          <nav className="grid gap-2 md:grid-cols-2">
+            <a href="#introduction" className="text-sm text-primary hover:underline">Introduction</a>
+            <a href="#information-collected" className="text-sm text-primary hover:underline">1. Information We Collect</a>
+            <a href="#how-we-use" className="text-sm text-primary hover:underline">2. How We Use Your Information</a>
+            <a href="#legal-basis" className="text-sm text-primary hover:underline">3. Legal Basis for Processing</a>
+            <a href="#how-we-share" className="text-sm text-primary hover:underline">4. How We Share Your Information</a>
+            <a href="#protection-measures" className="text-sm text-primary hover:underline">5. Privacy Protection Measures</a>
+            <a href="#your-rights" className="text-sm text-primary hover:underline">6. Your Rights and Choices</a>
+            <a href="#cookies" className="text-sm text-primary hover:underline">7. Cookies and Tracking Technologies</a>
+            <a href="#data-retention" className="text-sm text-primary hover:underline">8. Data Retention</a>
+            <a href="#children" className="text-sm text-primary hover:underline">9. Children's Privacy</a>
+            <a href="#international" className="text-sm text-primary hover:underline">10. International Users</a>
+            <a href="#changes" className="text-sm text-primary hover:underline">11. Changes to This Privacy Policy</a>
+            <a href="#third-party" className="text-sm text-primary hover:underline">12. Third-Party Links</a>
+            <a href="#contact" className="text-sm text-primary hover:underline">13. Contact Us About Privacy</a>
+            <a href="#consent" className="text-sm text-primary hover:underline">14. Consent</a>
+          </nav>
+        </div>
+
         <div className="prose prose-invert prose-neutral max-w-none space-y-8">
-          <section>
+          <section id="introduction">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               Introduction
             </h2>
@@ -53,7 +77,7 @@ export default function PrivacyPage() {
             </p>
           </section>
 
-          <section>
+          <section id="information-collected">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               1. Information We Collect
             </h2>
@@ -119,7 +143,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="how-we-use">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               2. How We Use Your Information
             </h2>
@@ -178,7 +202,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="legal-basis">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               3. Legal Basis for Processing
             </h2>
@@ -193,7 +217,7 @@ export default function PrivacyPage() {
             </ul>
           </section>
 
-          <section>
+          <section id="how-we-share">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               4. How We Share Your Information
             </h2>
@@ -283,7 +307,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="protection-measures">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               5. Privacy Protection Measures
             </h2>
@@ -333,7 +357,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="your-rights">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               6. Your Rights and Choices
             </h2>
@@ -406,7 +430,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="cookies">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               7. Cookies and Tracking Technologies
             </h2>
@@ -443,7 +467,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="data-retention">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               8. Data Retention
             </h2>
@@ -456,7 +480,7 @@ export default function PrivacyPage() {
             </ul>
           </section>
 
-          <section>
+          <section id="children">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               9. Children's Privacy
             </h2>
@@ -465,7 +489,7 @@ export default function PrivacyPage() {
             </p>
           </section>
 
-          <section>
+          <section id="international">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               10. International Users
             </h2>
@@ -474,7 +498,7 @@ export default function PrivacyPage() {
             </p>
           </section>
 
-          <section>
+          <section id="changes">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               11. Changes to This Privacy Policy
             </h2>
@@ -491,7 +515,7 @@ export default function PrivacyPage() {
             </p>
           </section>
 
-          <section>
+          <section id="third-party">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               12. Third-Party Links
             </h2>
@@ -500,7 +524,7 @@ export default function PrivacyPage() {
             </p>
           </section>
 
-          <section>
+          <section id="contact">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               13. Contact Us About Privacy
             </h2>
@@ -536,7 +560,7 @@ export default function PrivacyPage() {
             </div>
           </section>
 
-          <section>
+          <section id="consent">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               14. Consent
             </h2>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -43,8 +43,33 @@ export default function TermsPage() {
           </p>
         </div>
 
+        {/* Table of Contents */}
+        <div className="mb-12 rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 font-grotesk text-xl font-bold text-foreground">
+            Table of Contents
+          </h2>
+          <nav className="grid gap-2 md:grid-cols-2">
+            <a href="#introduction" className="text-sm text-primary hover:underline">Introduction</a>
+            <a href="#acceptance" className="text-sm text-primary hover:underline">1. Acceptance of Terms</a>
+            <a href="#dusa-affiliation" className="text-sm text-primary hover:underline">2. DUSA Affiliation and Governance</a>
+            <a href="#eligibility" className="text-sm text-primary hover:underline">3. Eligibility and Account Registration</a>
+            <a href="#portal-usage" className="text-sm text-primary hover:underline">4. Portal Usage</a>
+            <a href="#privacy" className="text-sm text-primary hover:underline">5. Member Data and Privacy</a>
+            <a href="#intellectual-property" className="text-sm text-primary hover:underline">6. Intellectual Property</a>
+            <a href="#events" className="text-sm text-primary hover:underline">7. Events and Activities</a>
+            <a href="#financial" className="text-sm text-primary hover:underline">8. Financial Matters</a>
+            <a href="#termination" className="text-sm text-primary hover:underline">9. Termination and Suspension</a>
+            <a href="#disclaimers" className="text-sm text-primary hover:underline">10. Disclaimers</a>
+            <a href="#liability" className="text-sm text-primary hover:underline">11. Limitation of Liability</a>
+            <a href="#changes" className="text-sm text-primary hover:underline">12. Changes to Terms</a>
+            <a href="#governing-law" className="text-sm text-primary hover:underline">13. Governing Law</a>
+            <a href="#general" className="text-sm text-primary hover:underline">14. General Provisions</a>
+            <a href="#contact" className="text-sm text-primary hover:underline">15. Contact Information</a>
+          </nav>
+        </div>
+
         <div className="prose prose-invert prose-neutral max-w-none space-y-8">
-          <section>
+          <section id="introduction">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               Introduction
             </h2>
@@ -53,7 +78,7 @@ export default function TermsPage() {
             </p>
           </section>
 
-          <section>
+          <section id="acceptance">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               1. Acceptance of Terms
             </h2>
@@ -62,7 +87,7 @@ export default function TermsPage() {
             </p>
           </section>
 
-          <section>
+          <section id="dusa-affiliation">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               2. DUSA Affiliation and Governance
             </h2>
@@ -86,7 +111,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="eligibility">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               3. Eligibility and Account Registration
             </h2>
@@ -109,7 +134,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="portal-usage">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               4. Portal Usage
             </h2>
@@ -144,7 +169,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="privacy">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               5. Member Data and Privacy
             </h2>
@@ -169,7 +194,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="intellectual-property">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               6. Intellectual Property
             </h2>
@@ -186,7 +211,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="events">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               7. Events and Activities
             </h2>
@@ -209,7 +234,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="financial">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               8. Financial Matters
             </h2>
@@ -226,7 +251,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="termination">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               9. Termination and Suspension
             </h2>
@@ -249,7 +274,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="disclaimers">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               10. Disclaimers
             </h2>
@@ -272,7 +297,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="liability">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               11. Limitation of Liability
             </h2>
@@ -291,7 +316,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="changes">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               12. Changes to Terms
             </h2>
@@ -308,7 +333,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="governing-law">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               13. Governing Law
             </h2>
@@ -325,7 +350,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="general">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               14. General Provisions
             </h2>
@@ -345,7 +370,7 @@ export default function TermsPage() {
             </div>
           </section>
 
-          <section>
+          <section id="contact">
             <h2 className="mb-4 font-grotesk text-2xl font-bold text-foreground">
               15. Contact Information
             </h2>


### PR DESCRIPTION
Enhanced both legal pages with interactive navigation:

✨ Features Added:
- Table of contents with jump links (2-column grid on desktop)
- Section IDs for smooth scrolling navigation
- Consistent design matching the Accessibility page

📄 Terms and Conditions Page:
- 16 sections with anchor links (Introduction + sections 1-15)
- IDs: #introduction, #acceptance, #dusa-affiliation, #eligibility, #portal-usage, #privacy, #intellectual-property, #events, #financial, #termination, #disclaimers, #liability, #changes, #governing-law, #general, #contact

📄 Privacy Policy Page:
- 15 sections with anchor links (Introduction + sections 1-14)
- IDs: #introduction, #information-collected, #how-we-use, #legal-basis, #how-we-share, #protection-measures, #your-rights, #cookies, #data-retention, #children, #international, #changes, #third-party, #contact, #consent

🎨 UX Improvements:
- Easy section navigation for long legal documents
- Mobile-responsive 2-column layout
- Matching visual style across all three legal pages
- Improved accessibility with skip navigation

https://claude.ai/code/session_0173WXx9MBEk7WfY5TH8EbLS