### PR TITLE
Add feature flag to block content pages (blog, events, projects, partnerships)

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -10,11 +10,23 @@ import {
   BlogCategories,
   BlogCTA,
 } from "@/components/blog";
+import ComingSoon from "@/components/auth/ComingSoon";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
+import { featureFlags } from "@/lib/feature-flags";
 import type { BlogPost, BlogCategory, BlogCategoryInfo, BlogListResponse } from "@/types";
 
 export default function BlogPage() {
+  // Show coming soon page if content pages are disabled
+  if (featureFlags.CONTENT_PAGES_DISABLED) {
+    return (
+      <main className="min-h-screen bg-background">
+        <Navbar />
+        <ComingSoon type="blog" />
+        <Footer />
+      </main>
+    );
+  }
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [featuredPosts, setFeaturedPosts] = useState<BlogPost[]>([]);
   const [categories, setCategories] = useState<BlogCategoryInfo[]>([]);

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -2,8 +2,10 @@ import AccessibilitySection from '@/components/events/AccessibilitySection';
 import EventCardsGrid from '@/components/events/EventCardsGrid';
 import EventsCTA from '@/components/events/EventsCTA';
 import EventsHero from '@/components/events/EventsHero';
+import ComingSoon from '@/components/auth/ComingSoon';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
+import { featureFlags } from '@/lib/feature-flags';
 
 import type { Metadata } from 'next';
 
@@ -28,6 +30,17 @@ export const metadata: Metadata = {
 };
 
 export default function EventsPage() {
+  // Show coming soon page if content pages are disabled
+  if (featureFlags.CONTENT_PAGES_DISABLED) {
+    return (
+      <main className="min-h-screen bg-background">
+        <Navbar />
+        <ComingSoon type="events" />
+        <Footer />
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-background">
       <Navbar />

--- a/app/partnership/page.tsx
+++ b/app/partnership/page.tsx
@@ -1,3 +1,4 @@
+import ComingSoon from '@/components/auth/ComingSoon';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
 import PartnershipsHero from '@/components/partnerships/PartnershipsHero';
@@ -6,6 +7,7 @@ import PartnershipTiers from '@/components/partnerships/PartnershipTiers';
 import SuccessStories from '@/components/partnerships/SuccessStories';
 import PartnershipProcess from '@/components/partnerships/PartnershipProcess';
 import PartnershipsCTA from '@/components/partnerships/PartnershipsCTA';
+import { featureFlags } from '@/lib/feature-flags';
 
 import type { Metadata } from 'next';
 
@@ -32,6 +34,17 @@ export const metadata: Metadata = {
 };
 
 export default function PartnershipsPage() {
+  // Show coming soon page if content pages are disabled
+  if (featureFlags.CONTENT_PAGES_DISABLED) {
+    return (
+      <main className="min-h-screen bg-background">
+        <Navbar />
+        <ComingSoon type="partnerships" />
+        <Footer />
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-background">
       <Navbar />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,11 +1,24 @@
+import ComingSoon from '@/components/auth/ComingSoon';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
 import ExplainerSection from '@/components/projects/ExplainerSection';
 import ProjectCardsGrid from '@/components/projects/ProjectCardsGrid';
 import ProjectsCTA from '@/components/projects/ProjectsCTA';
 import ProjectsHero from '@/components/projects/ProjectsHero';
+import { featureFlags } from '@/lib/feature-flags';
 
 export default function ProjectsPage() {
+  // Show coming soon page if content pages are disabled
+  if (featureFlags.CONTENT_PAGES_DISABLED) {
+    return (
+      <main className="min-h-screen bg-background">
+        <Navbar />
+        <ComingSoon type="projects" />
+        <Footer />
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-background">
       <Navbar />

--- a/components/auth/ComingSoon.tsx
+++ b/components/auth/ComingSoon.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useState } from "react";
 
 interface ComingSoonProps {
-  type: "login" | "join";
+  type: "login" | "join" | "blog" | "events" | "projects" | "partnerships";
 }
 
 export default function ComingSoon({ type }: ComingSoonProps) {
@@ -173,10 +173,12 @@ export default function ComingSoon({ type }: ComingSoonProps) {
           transition={{ delay: 0.4 }}
           className="text-xl text-muted-foreground mb-4"
         >
-          {type === "login"
-            ? "Member portal is getting ready for liftoff"
-            : "Registration is preparing for launch"
-          }
+          {type === "login" && "Member portal is getting ready for liftoff"}
+          {type === "join" && "Registration is preparing for launch"}
+          {type === "blog" && "Our blog is getting ready for liftoff"}
+          {type === "events" && "Events page is preparing for launch"}
+          {type === "projects" && "Projects showcase is getting ready"}
+          {type === "partnerships" && "Partnerships page is preparing for launch"}
         </motion.p>
 
         {/* Description */}
@@ -186,10 +188,12 @@ export default function ComingSoon({ type }: ComingSoonProps) {
           transition={{ delay: 0.5 }}
           className="text-muted-foreground mb-8 max-w-md mx-auto"
         >
-          {type === "login"
-            ? "We're building something amazing for DSEC members. The login feature will be available soon."
-            : "We're putting the finishing touches on our membership system. Join the waitlist to be the first to know when we launch."
-          }
+          {type === "login" && "We're building something amazing for DSEC members. The login feature will be available soon."}
+          {type === "join" && "We're putting the finishing touches on our membership system. Join the waitlist to be the first to know when we launch."}
+          {type === "blog" && "We're crafting insightful articles and tutorials for the DSEC community. Join the waitlist to be notified when we launch."}
+          {type === "events" && "We're preparing an exciting lineup of events for you. Join the waitlist to be the first to know when registration opens."}
+          {type === "projects" && "We're curating an amazing showcase of student projects. Join the waitlist to be notified when we launch."}
+          {type === "partnerships" && "We're building exciting partnership opportunities. Join the waitlist to be the first to know when this page goes live."}
         </motion.p>
 
         {/* Feature badges */}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -11,6 +11,12 @@ export const featureFlags = {
    * and users will see a "Coming Soon" message instead.
    */
   AUTH_DISABLED: true,
+
+  /**
+   * When true, content pages (blog, events, projects, partnerships)
+   * will be disabled and users will see a "Coming Soon" message instead.
+   */
+  CONTENT_PAGES_DISABLED: true,
 } as const;
 
 export type FeatureFlags = typeof featureFlags;


### PR DESCRIPTION
Extends the feature flag system to allow temporarily disabling content pages
with the same "Coming Soon" experience as the login/join pages. Updates the
ComingSoon component to support the new page types with contextual messaging.

https://claude.ai/code/session_01XARL3yYyLCUSjM2jUnfiU4